### PR TITLE
Remove to_owned Declarations on `with_suffixes` 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,10 +197,12 @@ impl Scales {
     }
 
     /// Sets the suffixes listing appropriately
-    pub fn with_suffixes(&mut self, suffixes: Vec<String>) -> &mut Self {
+    pub fn with_suffixes(&mut self, suffixes: Vec<&str>) -> &mut Self {
         self.suffixes = Vec::new();
 
         for suffix in suffixes {
+            // This should be to_owned to be clear about intent. 
+            // https://users.rust-lang.org/t/to-string-vs-to-owned-for-string-literals/1441/6
             self.suffixes.push(suffix.to_owned());
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ impl Scales {
     pub fn SI() -> Self {
         Scales {
             base: 1000,
-            suffixes: [
+            suffixes: vec![
                 "".to_owned(),
                 "k".to_owned(),
                 "M".to_owned(),
@@ -167,7 +167,7 @@ impl Scales {
                 "E".to_owned(),
                 "Z".to_owned(),
                 "Y".to_owned(),
-            ].to_vec(),
+            ],
         }
     }
 
@@ -175,7 +175,7 @@ impl Scales {
     pub fn Binary() -> Self {
         Scales {
             base: 1000,
-            suffixes: [
+            suffixes: vec![
                 "".to_owned(),
                 "ki".to_owned(),
                 "Mi".to_owned(),
@@ -185,7 +185,7 @@ impl Scales {
                 "Ei".to_owned(),
                 "Zi".to_owned(),
                 "Yi".to_owned(),
-            ].to_vec(),
+            ],
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ impl Scales {
         self.suffixes = Vec::new();
 
         for suffix in suffixes {
-            // This should be to_owned to be clear about intent. 
+            // This should be to_owned to be clear about intent.
             // https://users.rust-lang.org/t/to-string-vs-to-owned-for-string-literals/1441/6
             self.suffixes.push(suffix.to_owned());
         }

--- a/tests/demo.rs
+++ b/tests/demo.rs
@@ -69,7 +69,7 @@ test_suite! {
 
         scales
             .with_base(1024)
-            .with_suffixes(["".to_owned(),"ki".to_owned(), "Mi".to_owned(), "Gi".to_owned(), "Ti".to_owned(), "Pi".to_owned(), "Ei".to_owned(), "Zi".to_owned(), "Yi".to_owned()].to_vec());
+            .with_suffixes(["","ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"].to_vec());
 
         assert_eq!(Formatter::new()
             .with_scales(scales)

--- a/tests/demo.rs
+++ b/tests/demo.rs
@@ -69,7 +69,7 @@ test_suite! {
 
         scales
             .with_base(1024)
-            .with_suffixes(["","ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"].to_vec());
+            .with_suffixes(vec!["","ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"]);
 
         assert_eq!(Formatter::new()
             .with_scales(scales)


### PR DESCRIPTION
## Overview

This PR proposes changes to address a usability bug. instead of passing a vector of owned strings it can pass references now. 

```rust
vec![
    "".to_owned(),
    "ki".to_owned(),
    "Mi".to_owned(),
    "Gi".to_owned(),
    "Ti".to_owned(),
    "Pi".to_owned(),
    "Ei".to_owned(),
    "Zi".to_owned(),
    "Yi".to_owned(),
]
```

is now replaced with 

```
vec!["", "ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"]
```

## Test Cases & Validation Steps
* Automated test cases were updated to support this change. 

## TODO

- [x] run `cargo test` and have 0 failed or skipped test cases
- [x] run `cargo fmt` and have 0 modified files
- [x] merge `develop` and validate that it no features are broken
- [x] document new public API
- [x] provide new test cases for any new/modified behavior
- [x] adhere to project standards & practices