### PR TITLE
Remove println macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,8 +213,6 @@ impl Scales {
         let ndx = 0;
 
         for ndx in 0..self.suffixes.len() {
-            println!("{}", self.suffixes[ndx]);
-
             if value == self.suffixes[ndx] {
                 return self.base.pow(ndx as u32) as f64;
             }
@@ -235,14 +233,6 @@ impl Scales {
             _value /= self.base as f64;
             index += 1;
         }
-
-        println!(
-            "\t\t{}: {} {} --- {}",
-            value,
-            index,
-            self.base.pow(index as u32),
-            value / (self.base.pow(index as u32) as f64)
-        );
 
         ScaledValue {
             value: (value / self.base.pow((index) as u32) as f64) as f32,


### PR DESCRIPTION
Hey there, I was using this library in one of my crates and realized that it was printing data when I would run format or parse where they should not print anything.