### PR TITLE
Address naming, and sizing issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ impl Scales {
             base: 1000,
             suffixes: vec![
                 "".to_owned(),
-                "k".to_owned(),
+                "K".to_owned(),
                 "M".to_owned(),
                 "G".to_owned(),
                 "T".to_owned(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,10 @@
 //!     .format(1000000.0);
 //! # assert_eq!(tmpStr2, "1.00 M");
 //!
-//! // "1.00 B"
+//! // "1.00 G"
 //! let tmpStr3 = human_format::Formatter::new()
 //!     .format(1000000000.0);
-//! # assert_eq!(tmpStr3, "1.00 B");
+//! # assert_eq!(tmpStr3, "1.00 G");
 //! ```
 //!
 //! If you are so inspired you can even try playing with units and customizing your `Scales`
@@ -44,7 +44,7 @@
 
 #[derive(Debug)]
 struct ScaledValue {
-    value: f32,
+    value: f64,
     suffix: String,
 }
 
@@ -58,6 +58,18 @@ pub struct Formatter {
     forced_suffix: String,
 }
 
+impl Default for Formatter {
+    fn default() -> Self {
+        Formatter {
+            decimals: 2,
+            separator: " ".to_owned(),
+            scales: Scales::SI(),
+            forced_units: "".to_owned(),
+            forced_suffix: "".to_owned(),
+        }
+    }
+}
+
 /// Provide a customized scaling scheme for your own modeling.
 #[derive(Debug)]
 pub struct Scales {
@@ -68,13 +80,7 @@ pub struct Scales {
 impl Formatter {
     /// Initializes a new `Formatter` with default values.
     pub fn new() -> Self {
-        Formatter {
-            decimals: 2,
-            separator: " ".to_owned(),
-            scales: Scales::SI(),
-            forced_units: "".to_owned(),
-            forced_suffix: "".to_owned(),
-        }
+        Default::default()
     }
 
     /// Sets the decimals value for formatting the string.
@@ -143,7 +149,13 @@ impl Formatter {
 
         let magnitude_multiplier = self.scales.get_magnitude_multipler(&suffix);
 
-        (result * magnitude_multiplier)
+        result * magnitude_multiplier
+    }
+}
+
+impl Default for Scales {
+    fn default() -> Self {
+        Scales::SI()
     }
 }
 
@@ -154,6 +166,7 @@ impl Scales {
     }
 
     /// Instantiates a new `Scales` with SI keys
+    #[allow(non_snake_case)]
     pub fn SI() -> Self {
         Scales {
             base: 1000,
@@ -161,7 +174,7 @@ impl Scales {
                 "".to_owned(),
                 "k".to_owned(),
                 "M".to_owned(),
-                "B".to_owned(),
+                "G".to_owned(),
                 "T".to_owned(),
                 "P".to_owned(),
                 "E".to_owned(),
@@ -172,6 +185,7 @@ impl Scales {
     }
 
     /// Instantiates a new `Scales` with Binary keys
+    #[allow(non_snake_case)]
     pub fn Binary() -> Self {
         Scales {
             base: 1024,
@@ -216,7 +230,7 @@ impl Scales {
             }
         }
 
-        return 0.0;
+        0.0
     }
 
     fn to_scaled_value(&self, value: f64) -> ScaledValue {
@@ -233,7 +247,7 @@ impl Scales {
         }
 
         ScaledValue {
-            value: (value / self.base.pow((index) as u32) as f64) as f32,
+            value: value / self.base.pow((index) as u32) as f64,
             suffix: self.suffixes[index].to_owned(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,10 @@
 //! Print some human readable strings
 //!
 //! ```rust
-//! // "1.00 k"
+//! // "1.00 K"
 //! let tmpStr = human_format::Formatter::new()
 //!     .format(1000.0);
-//! # assert_eq!(tmpStr, "1.00 k");
+//! # assert_eq!(tmpStr, "1.00 K");
 //!
 //! // "1.00 M"
 //! let tmpStr2 = human_format::Formatter::new()
@@ -235,19 +235,20 @@ impl Scales {
 
     fn to_scaled_value(&self, value: f64) -> ScaledValue {
         let mut index: usize = 0;
-        let mut _value: f64 = value;
+        let base: f64 = self.base as f64;
+        let mut value = value;
 
         loop {
-            if _value < (self.base as f64) {
+            if value < base {
                 break;
             }
 
-            _value /= self.base as f64;
+            value /= base;
             index += 1;
         }
 
         ScaledValue {
-            value: value / self.base.pow((index) as u32) as f64,
+            value,
             suffix: self.suffixes[index].to_owned(),
         }
     }

--- a/tests/demo.rs
+++ b/tests/demo.rs
@@ -9,28 +9,28 @@ test_suite! {
     test should_allow_use_of_si_scale_implicitly() {
         assert_eq!(Formatter::new()
             .format(1000 as f64),
-            "1.00 k");
+            "1.00 K");
     }
 
     test should_allow_explicit_decimals() {
         assert_eq!(Formatter::new()
             .with_decimals(1)
             .format(1000 as f64),
-            "1.0 k");
+            "1.0 K");
     }
 
     test should_allow_explicit_separator() {
         assert_eq!(Formatter::new()
             .with_separator(" - ")
             .format(1000 as f64),
-            "1.00 - k");
+            "1.00 - K");
     }
 
     test should_allow_use_of_si_scale_explicitly() {
         assert_eq!(Formatter::new()
             .with_scales(Scales::SI())
             .format(1000 as f64),
-            "1.00 k");
+            "1.00 K");
     }
 
     test should_allow_use_of_binary_scale_explicitly() {
@@ -48,7 +48,7 @@ test_suite! {
             "100.00 KiB");
     }
 
-    test should_output_10_24MiB() {
+    test should_output_10_24_mib() {
         assert_eq!(Formatter::new()
             .with_scales(Scales::Binary())
             .with_units("B")
@@ -56,12 +56,20 @@ test_suite! {
             "1.00 MiB");
     }
 
+    test should_output_75_11_pib() {
+        assert_eq!(Formatter::new()
+            .with_scales(Scales::Binary())
+            .with_units("B")
+            .format(84_567_942_345_572_238.0),
+            "75.11 PiB");
+    }
+
     test should_allow_explicit_suffix_and_unit() {
         assert_eq!(Formatter::new()
             .with_suffix("k")
             .with_units("m")
             .format(1024 as f64),
-            "1.02 km");
+            "1.02 Km");
     }
 
     test should_allow_use_of_explicit_scale() {
@@ -80,7 +88,7 @@ test_suite! {
 
     test should_allow_parsing_to_f64() {
         assert_eq!(Formatter::new()
-            .parse("1.00 k"), 1000.0);
+            .parse("1.00 K"), 1000.0);
     }
 
     test should_allow_parsing_binary_values_to_f64() {


### PR DESCRIPTION
## Overview

This allows processing full f64 values.  So PiB can actually be processed (see new test in demo.rs).

## Test Cases & Validation Steps

## TODO

- [x] run `cargo test` and have 0 failed or skipped test cases
- [x] run `cargo fmt` and have 0 modified files
- [x] merge `develop` and validate that it no features are broken
- [x] document new public API
- [x] provide new test cases for any new/modified behavior
- [x] adhere to project standards & practices

## Further Enhancements

Fix processing of Large values.  Removes f32 computations and storage in ScaledValue.
Adds Default implementation to Scales and Formatter, to make clippy happy.
Fixes SI naming `k` to `K`, and `b` to `G` (this fixes #12)