### PR TITLE
Add Formatter::try_parse()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ homepage = "https://github.com/BobGneu/human-format-rs"
 repository = "https://github.com/BobGneu/human-format-rs"
 documentation = "https://docs.rs/human_format"
 readme = "README.md"
-license-file = "LICENSE"
 keywords = ["numbers", "formatting", "filesize", "human", "magnitude"]
 categories = ["value-formatting", "no-std"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 [badges]
 travis-ci = { repository = "BobGneu/human-format-rs" }
 appveyor =  { repository = "BobGneu/human-format-rs" }
-maintenace = { status = "actively-developed" }
+maintenance = { status = "passively-maintained" }
 
 [dev-dependencies]
 galvanic-test = "0.1.3"

--- a/tests/demo.rs
+++ b/tests/demo.rs
@@ -91,6 +91,11 @@ test_suite! {
             .parse("1.00 K"), 1000.0);
     }
 
+    test should_allow_try_parsing_to_f64() {
+        assert_eq!(Formatter::new()
+            .try_parse("1.00 M"), Ok(1000000.0));
+    }
+
     test should_allow_parsing_binary_values_to_f64() {
         assert_eq!(Formatter::new()
             .with_scales(Scales::Binary())
@@ -102,5 +107,30 @@ test_suite! {
             .with_scales(Scales::Binary())
             .with_units("B")
             .parse("1.00 KiB"), 1024.0);
+    }
+
+    test should_allow_try_parsing_binary_values_with_units_to_f64() {
+        assert_eq!(Formatter::new()
+            .with_scales(Scales::Binary())
+            .with_units("B")
+            .try_parse("1.00 KiB"), Ok(1024.0));
+    }
+
+    test try_parse_explicit_suffix_and_unit() {
+        assert_eq!(Formatter::new()
+                   .with_units("m")
+                   .try_parse("1.024Mm"), Ok(1024000.0));
+    }
+
+    test try_parse_explicit_suffix_and_unitless() {
+        assert_eq!(Formatter::new()
+                   .with_units("m")
+                   .try_parse("1.024M"), Ok(1024000.0));
+    }
+
+    test try_parse_very_large_value() {
+        assert_eq!(Formatter::new()
+                   .with_units("B")
+                   .try_parse("2PB"), Ok(2_000_000_000_000_000.0));
     }
 }


### PR DESCRIPTION
Add parser that doesn't panic on bad input.

## Overview

This adds `Formatter::try_parse()` that returns a `Result` instead of just panicing on badly formatted

## Test Cases & Validation Steps

Added test cases

## TODO

- [x] run `cargo test` and have 0 failed or skipped test cases
- [x] run `cargo fmt` and have 0 modified files
- [x] merge `develop` and validate that it no features are broken
- [x] document new public API
- [x] provide new test cases for any new/modified behavior
- [x] adhere to project standards & practices
