### PR TITLE
Add Formatter::try_parse() - with updated variable name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "human_format"
 path = "src/lib.rs"
 
 [badges]
-maintenance = {status = "passively-maintained"}
+maintenance = { status = "passively-maintained" }
 
 [dev-dependencies]
 galvanic-test = "0.1.3"

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Format check included in build
+- Improve error handling in try_parse with better ergonomics - [PR#19]https://github.com/BobGneu/human-format-rs/pull/9 by [@jgrund](https://github.com/jgrund)
 
 ### Removed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@ impl Formatter {
     /// Attempt to parse a string back into a float value.
     pub fn try_parse(&self, value: &str) -> Result<f64, String> {
         let value = value.to_string();
+
         // Remove suffix if present
         let value = value.trim_end_matches(&self.forced_units).to_string();
 
@@ -167,20 +168,16 @@ impl Formatter {
                 break;
             }
         }
+
         let suffix = value
             .trim_start_matches(&number)
             .trim_start_matches(&self.separator)
             .to_string();
 
-        let result = number.parse::<f64>().map_err(|e| e.to_string())?;
-
+        let number = number.parse::<f64>().map_err(|e| e.to_string())?;
         let magnitude_multiplier = self.scales.try_get_magnitude_multiplier(&suffix)?;
 
-        if magnitude_multiplier > 0.0 {
-            Ok(result * magnitude_multiplier)
-        } else {
-            Err(format!("Unknown suffix: {}", suffix))
-        }
+        Ok(number * magnitude_multiplier)
     }
 }
 

--- a/tests/demo.rs
+++ b/tests/demo.rs
@@ -123,6 +123,16 @@ test_suite! {
             .try_parse("1.00 KiB"), Ok(1024.0));
     }
 
+    test should_allow_try_parsing_binary_values_with_units_to_f642() {
+        let result = Formatter::new()
+            .with_scales(Scales::Binary())
+            .with_units("B")
+            .try_parse("1.00 DN");
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Unknown suffix: DN, valid suffixes are: Ki, Mi, Gi, Ti, Pi, Ei, Zi, Yi");
+    }
+
     test try_parse_explicit_suffix_and_unit() {
         assert_eq!(Formatter::new()
                    .with_units("m")


### PR DESCRIPTION
Prior author: Nathaniel Clark <nclark@whamcloud.com>

## Overview

This PR proposes updating the implementation of try_parse such that it follows more modern error handling patterns and surfaces a better error when a better implementation of the lookup for the base by suffix that surfaces errors. 

Largely this is just addressing a merge conflict as I caught a slightly different implementation earlier. 

## Test Cases & Validation Steps

- Included new test case to check the error response being returned. 

## TODO

- [x] run `cargo test` and have 0 failed or skipped test cases
- [x] run `cargo fmt` and have 0 modified files
- [x] merge `develop` and validate that it no features are broken
- [x] document new public API
- [x] provide new test cases for any new/modified behavior
- [ ] adhere to project standards & practices
