### PR TITLE
Support Octillions and Nonillions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,8 @@ impl Scales {
                 "E".to_owned(),
                 "Z".to_owned(),
                 "Y".to_owned(),
+                "R".to_owned(),
+                "Q".to_owned(),
             ],
         }
     }
@@ -218,6 +220,8 @@ impl Scales {
                 "Ei".to_owned(),
                 "Zi".to_owned(),
                 "Yi".to_owned(),
+                "Ri".to_owned(),
+                "Qi".to_owned(),
             ],
         }
     }
@@ -282,7 +286,7 @@ impl Scales {
         let mut value = value;
 
         loop {
-            if value < base {
+            if value < base || index == self.suffixes.len() - 1 {
                 break;
             }
 

--- a/tests/demo.rs
+++ b/tests/demo.rs
@@ -163,7 +163,7 @@ mod demo_examples {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            "Unknown suffix: DN, valid suffixes are: ki, Mi, Gi, Ti, Pi, Ei, Zi, Yi"
+            "Unknown suffix: DN, valid suffixes are: ki, Mi, Gi, Ti, Pi, Ei, Zi, Yi, Ri, Qi"
         );
     }
 

--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -27,5 +27,13 @@ mod formatting {
         assert_eq!(Formatter::new().format(1.2123123422324232e18), "1.21 E");
 
         assert_eq!(Formatter::new().format(1.2123123422324232e26), "121.23 Y");
+
+        assert_eq!(Formatter::new().format(5.58559632792669e27), "5.59 R");
+
+        assert_eq!(Formatter::new().format(5.58559632792669e30), "5.59 Q");
+
+        assert_eq!(Formatter::new().format(5.58559632792669e31), "55.86 Q");
+
+        assert_eq!(Formatter::new().format(5.58559632792669e35), "558559.63 Q");
     }
 }

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -17,13 +17,13 @@ mod parsing {
     }
 
     #[test]
-    fn should_parse_55_86_q_as_5_586_e_31() {
+    fn should_parse_55_86_q_as_5_586_e31() {
         let formatter = Formatter::new();
         assert_eq!(formatter.parse("55.86 Q"), 5.586e31);
     }
 
     #[test]
-    fn should() {
+    fn should_parse_558559_63_q_as_5_5855963e35() {
         let formatter = Formatter::new();
         assert_eq!(formatter.parse("558559.63 Q"), 5.5855963e35);
     }

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -17,6 +17,18 @@ mod parsing {
     }
 
     #[test]
+    fn should_parse_55_86_q_as_5_586_e_31() {
+        let formatter = Formatter::new();
+        assert_eq!(formatter.parse("55.86 Q"), 5.586e31);
+    }
+
+    #[test]
+    fn should() {
+        let formatter = Formatter::new();
+        assert_eq!(formatter.parse("558559.63 Q"), 5.5855963e35);
+    }
+
+    #[test]
     fn should_parse_1494_k_as_1494222() {
         let mut formatter = Formatter::new();
         formatter.with_decimals(3);


### PR DESCRIPTION
## Overview

This PR adds support for Octillions and Nonillions while also allowing for even larger numbers by using last suffix instead of crashing from out of bounds error.

## Test Cases & Validation Steps

- `parsing::should_parse_558559_63_q_as_5_5855963e35`
- `parsing::should_parse_55_86_q_as_5_586_e31`
- modified `formatting::should_handle_large_numbers_in_scientific_notation` to parse numbers with larger exponents than supported

## TODO

- [x] run `cargo test` and have 0 failed or skipped test cases
- [x] run `cargo fmt` and have 0 modified files
- [ ] merge `develop` and validate that it no features are broken
- [ ] document new public API
- [x] provide new test cases for any new/modified behavior
- [x] adhere to project standards & practices

## Further Enhancements

None