### PR TITLE
Binary suffix Ki should be with capital K

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,10 +191,10 @@ impl Formatter {
     /// // SI example
     /// let f = Formatter::new();
     /// assert_eq!(f.try_parse("1.00 k").unwrap(), 1000.0);
-    /// // Binary scales (ki = 1024)
+    /// // Binary scales (Ki = 1024)
     /// let mut fbin = Formatter::new();
     /// fbin.with_scales(Scales::Binary());
-    /// assert_eq!(fbin.try_parse("1.00 ki").unwrap(), 1024.0);
+    /// assert_eq!(fbin.try_parse("1.00 Ki").unwrap(), 1024.0);
     /// // Units specified via with_units() are automatically stripped from input
     /// let mut funit = Formatter::new();
     /// funit.with_units("B");
@@ -263,7 +263,7 @@ impl Formatter {
     /// // Binary example with units
     /// let mut fb = Formatter::new();
     /// fb.with_scales(Scales::Binary()).with_units("B");
-    /// assert_eq!(fb.parse_or_clamp("1.0 kiB", false).unwrap(), 1024.0);
+    /// assert_eq!(fb.parse_or_clamp("1.0 KiB", false).unwrap(), 1024.0);
     /// // Negative number with clamp
     /// assert_eq!(Formatter::new().parse_or_clamp("-1.0 k", true).unwrap(), -1000.0);
     /// ```
@@ -384,7 +384,7 @@ impl Scales {
             base: 1024,
             suffixes: vec![
                 "".to_owned(),
-                "ki".to_owned(),
+                "Ki".to_owned(),
                 "Mi".to_owned(),
                 "Gi".to_owned(),
                 "Ti".to_owned(),

--- a/tests/demo.rs
+++ b/tests/demo.rs
@@ -36,7 +36,7 @@ mod demo_examples {
             Formatter::new()
                 .with_scales(Scales::Binary())
                 .format(1024 as f64),
-            "1.00 ki"
+            "1.00 Ki"
         );
     }
 
@@ -47,7 +47,7 @@ mod demo_examples {
                 .with_scales(Scales::Binary())
                 .with_units("B")
                 .format(102400 as f64),
-            "100.00 kiB"
+            "100.00 KiB"
         );
     }
 
@@ -121,7 +121,7 @@ mod demo_examples {
         assert_eq!(
             Formatter::new()
                 .with_scales(Scales::Binary())
-                .try_parse("1.00 ki")
+                .try_parse("1.00 Ki")
                 .unwrap(),
             1024.0
         );
@@ -133,7 +133,7 @@ mod demo_examples {
             Formatter::new()
                 .with_scales(Scales::Binary())
                 .with_units("B")
-                .try_parse("1.00 kiB")
+                .try_parse("1.00 KiB")
                 .unwrap(),
             1024.0
         );
@@ -145,7 +145,7 @@ mod demo_examples {
             Formatter::new()
                 .with_scales(Scales::Binary())
                 .with_units("B")
-                .try_parse("1.00 kiB"),
+                .try_parse("1.00 KiB"),
             Ok(1024.0)
         );
     }

--- a/tests/formatting/binary.rs
+++ b/tests/formatting/binary.rs
@@ -13,7 +13,7 @@ fn binary_and_units_examples() {
             .with_scales(Scales::Binary())
             .with_units("B")
             .format(102400.0),
-        "100.00 kiB"
+        "100.00 KiB"
     );
     assert_eq!(
         Formatter::new()


### PR DESCRIPTION
## Overview
Wiki quotes IEC 60027-2 A.2 and ISO/IEC 80000:13-2025 and says the symbol for kibi is `Ki` with the capital K :https://en.wikipedia.org/wiki/Binary_prefix

## Test Cases & Validation Steps

## TODO

-   [x] run `cargo test` and have 0 failed or skipped test cases
-   [x] run `cargo fmt` and have 0 modified files
-   [x] run `cargo clippy -- -Dwarnings` and have 0 issues reported
-   [x] merge `develop` and validate that it no features are broken
-   [x] document new public API
-   [x] provide new test cases for any new/modified behavior
-   [x] adhere to project standards & practices


